### PR TITLE
Fix GitHub capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ The tunnels are configured in your
 *Networks > Tunnels*.
 <!--
 
-Notes to developers after forking or using the github template feature:
+Notes to developers after forking or using the GitHub template feature:
 - While developing comment out the 'image' key from 'example/config.yaml' to make the supervisor build the addon
   - Remember to put this back when pushing up your changes.
 - When you merge to the 'main' branch of your repository a new build will be triggered.
   - Make sure you adjust the 'version' key in 'example/config.yaml' when you do that.
   - Make sure you update 'example/CHANGELOG.md' when you do that.
-  - The first time this runs you might need to adjust the image configuration on github container registry to make it public
-  - You may also need to adjust the github Actions configuration (Settings > Actions > General > Workflow > Read & Write)
+  - The first time this runs you might need to adjust the image configuration on GitHub container registry to make it public
+  - You may also need to adjust the GitHub Actions configuration (Settings > Actions > General > Workflow > Read & Write)
 - Adjust the 'image' key in 'example/config.yaml' so it points to your username instead of 'home-assistant'.
   - This is where the build images will be published to.
 - Rename the example directory.


### PR DESCRIPTION
## Summary
- correct "github" to "GitHub" in README developer notes

## Testing
- `grep -n GitHub -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_684077cfc7648332a07ee6fb8daaa0e2