### PR TITLE
Bump cloudflared to 2026.1.2

### DIFF
--- a/cloudflared/CHANGELOG.md
+++ b/cloudflared/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2026.1.2
+
+- Bump cloudflared to 2026.1.2
+
 ## 2025.5.0
 
 - Bump cloudflared to 2025.5.0

--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -20,7 +20,7 @@ RUN \
     esac) && \
     if [ "$CLOUDFLARED_ARCH" != "unsupported" ]; then \
         curl -sSL -o /usr/local/bin/cloudflared \
-            "https://github.com/cloudflare/cloudflared/releases/download/2025.5.0/cloudflared-linux-${CLOUDFLARED_ARCH}" && \
+            "https://github.com/cloudflare/cloudflared/releases/download/2026.1.2/cloudflared-linux-${CLOUDFLARED_ARCH}" && \
         chmod +x /usr/local/bin/cloudflared; \
     else \
         echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1; \

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Cloudflare Tunnel client
-version: "2025.5.0"
+version: "2026.1.2"
 slug: cloudflared
 description: Client for Cloudflare Tunnel
 arch:


### PR DESCRIPTION
## Summary

- Bumps cloudflared from 2025.5.0 to 2026.1.2
- Updates Dockerfile download URL, addon version in config.yaml, and CHANGELOG.md