### PR TITLE
Remove deprecated architecture badges from addon README

### DIFF
--- a/cloudflared/README.md
+++ b/cloudflared/README.md
@@ -7,15 +7,9 @@ _Networks > Tunnels_.
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 
 *Cloudflare Tunnel* provides a secure way to connect to your services without exposing
 an external IP address. It establishes an encrypted tunnel between your infrastructure


### PR DESCRIPTION
## Summary
Remove armhf, armv7, and i386 architecture badges from cloudflared/README.md since these architectures are no longer supported by the Home Assistant builder.

## Test plan
- [x] Verify only aarch64 and amd64 badges remain