### PR TITLE
Add step to sync future branch after release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,4 @@ cloudflared/
    ## Full Changelog
    See [CHANGELOG.md](cloudflared/CHANGELOG.md) for complete details.
    ```
+10. Sync `future` with `main` to keep them aligned: `git checkout future && git merge main --no-edit && git push origin future`. This ensures both branches have identical content for the next release cycle.


### PR DESCRIPTION
## Summary
Add step 10 to the release process documenting that `future` should be synced with `main` after a release to keep both branches aligned.

This is important because squash-merging causes the branches to diverge (different commit histories).