### PR TITLE
Release 2026.2.1

### DIFF
--- a/cloudflared/CHANGELOG.md
+++ b/cloudflared/CHANGELOG.md
@@ -1,5 +1,11 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2026.2.1
+
+- Re-enable AppArmor profile with proper cloudflared-specific permissions
+- Update documentation to reflect Cloudflare UI navigation changes
+- Clean up build configuration
+
 ## 2026.2.0
 
 - Bump cloudflared to 2026.2.0

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Cloudflare Tunnel client
-version: "2026.2.0"
+version: "2026.2.1"
 slug: cloudflared
 description: Client for Cloudflare Tunnel
 arch:


### PR DESCRIPTION
## Summary
Bump addon version from 2026.2.0 to 2026.2.1.

### Changes
- Re-enable AppArmor profile with proper cloudflared-specific permissions
- Update documentation to reflect Cloudflare UI navigation changes
- Clean up build configuration

## Full Changelog
See [CHANGELOG.md](cloudflared/CHANGELOG.md) for complete details.

## Test plan
- [x] Lint passes on feature PR #38
- [ ] CI lint and build checks pass