### PR TITLE
Bump cloudflared to 2026.3.0 and harden workflow permissions

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -13,6 +13,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   init:
     runs-on: ubuntu-latest

--- a/cloudflared/CHANGELOG.md
+++ b/cloudflared/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2026.4.0
+
+- Bump cloudflared to 2026.3.0
+- Restrict default workflow permissions in builder workflow (security hardening)
+
 ## 2026.2.2
 
 - Disable AppArmor profile to fix boot loop / segfault (issue #41)

--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILD_FROM
 
 # Install Cloudflared based on architecture
 ARG BUILD_ARCH
-ARG CLOUDFLARED_VERSION="2026.2.0"
+ARG CLOUDFLARED_VERSION="2026.3.0"
 RUN \
     CLOUDFLARED_ARCH=$(case "${BUILD_ARCH}" in \
         "amd64")  echo "amd64" ;; \

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Cloudflare Tunnel client
-version: "2026.2.2"
+version: "2026.4.0"
 slug: cloudflared
 description: Client for Cloudflare Tunnel
 arch:


### PR DESCRIPTION
Update cloudflared binary from 2026.2.0 to 2026.3.0 and add a top-level `permissions: {}` to the Builder workflow so the GITHUB_TOKEN defaults to no access, resolving code-scanning alert #6.

Addon version: 2026.4.0