### PR TITLE
Bump cloudflared to 2026.5.1

### DIFF
--- a/cloudflared/CHANGELOG.md
+++ b/cloudflared/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2026.5.0
+
+- Bump cloudflared to 2026.5.1
+
 ## 2026.4.0
 
 - Bump cloudflared to 2026.3.0

--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILD_FROM
 
 # Install Cloudflared based on architecture
 ARG BUILD_ARCH
-ARG CLOUDFLARED_VERSION="2026.3.0"
+ARG CLOUDFLARED_VERSION="2026.5.1"
 RUN \
     CLOUDFLARED_ARCH=$(case "${BUILD_ARCH}" in \
         "amd64")  echo "amd64" ;; \

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Cloudflare Tunnel client
-version: "2026.4.0"
+version: "2026.5.0"
 slug: cloudflared
 description: Client for Cloudflare Tunnel
 arch:


### PR DESCRIPTION
## Summary

- Bumps the bundled `cloudflared` binary from `2026.3.0` to `2026.5.1`.
- Bumps the addon version to `2026.5.0`.
- Adds a corresponding `CHANGELOG.md` entry.

## Test plan

- [ ] Lint workflow passes
- [ ] Build workflow passes for `aarch64` and `amd64`
- [ ] Local test (`scripts/local-test.sh`) confirms the tunnel connects

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkitjBTV6JkNL1dYogsCyW)_